### PR TITLE
Create workflow to build the Docker image on any branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,16 @@ jobs:
 
 workflows:
   version: 2
-  build-master:
+  build-branch:
+    jobs:
+      - build
+
+  build-on-tag:
     jobs:
       - build_and_release:
           context: conntest-dockerhub-release
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
The Docker image will be build on any branch, to ensure the healthiness of this process. Apart from that, the "build_and_release" job will only be executed when we create a new tag in the repo.