### PR TITLE
Create alias for certain operations

### DIFF
--- a/generic_k8s_webhook/config_parser/entrypoint.py
+++ b/generic_k8s_webhook/config_parser/entrypoint.py
@@ -100,12 +100,15 @@ class GenericWebhookConfigManifest:
                 meta_op_parser=op_parser.MetaOperatorParser(
                     list_op_parser_classes=[
                         op_parser.AndParser,
+                        op_parser.AllParser,
                         op_parser.OrParser,
+                        op_parser.AnyParser,
                         op_parser.EqualParser,
                         op_parser.SumParser,
                         op_parser.NotParser,
                         op_parser.ListParser,
                         op_parser.ForEachParser,
+                        op_parser.MapParser,
                         op_parser.ContainParser,
                         op_parser.ConstParser,
                         op_parser.GetValueParser,

--- a/generic_k8s_webhook/config_parser/operator_parser.py
+++ b/generic_k8s_webhook/config_parser/operator_parser.py
@@ -100,6 +100,10 @@ class BinaryOpParser(OperatorParser):
 
 
 class AndParser(BinaryOpParser):
+    """
+    Deprecated. Use "all" instead
+    """
+
     @classmethod
     def get_name(cls) -> str:
         return "and"
@@ -109,7 +113,21 @@ class AndParser(BinaryOpParser):
         return operators.And
 
 
+class AllParser(AndParser):
+    """
+    Just an alias for "and". In the future, we'll deprecate "and" in favour of "all"
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "all"
+
+
 class OrParser(BinaryOpParser):
+    """
+    Deprecated. Use "any" instead
+    """
+
     @classmethod
     def get_name(cls) -> str:
         return "or"
@@ -117,6 +135,16 @@ class OrParser(BinaryOpParser):
     @classmethod
     def get_operator_cls(cls) -> operators.BinaryOp:
         return operators.Or
+
+
+class AnyParser(OrParser):
+    """
+    Just an alias for "or". In the future, we'll deprecate "or" in favour of "all"
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "any"
 
 
 class EqualParser(BinaryOpParser):
@@ -180,6 +208,10 @@ class ListParser(OperatorParser):
 
 
 class ForEachParser(OperatorParser):
+    """
+    Deprecated. Use "map" instead of "forEach"
+    """
+
     @classmethod
     def get_name(cls) -> str:
         return "forEach"
@@ -195,6 +227,16 @@ class ForEachParser(OperatorParser):
             return operators.ForEach(elements, op)
         except TypeError as e:
             raise ParsingException(f"Error when parsing {path_op}") from e
+
+
+class MapParser(ForEachParser):
+    """
+    It's an alias of ForEachParser. In the future, we'll deprecate "forEach" in favour of "map"
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "map"
 
 
 class ContainParser(OperatorParser):

--- a/generic_k8s_webhook/operators.py
+++ b/generic_k8s_webhook/operators.py
@@ -110,6 +110,7 @@ class And(BoolOp):
         return lhs and rhs
 
     def _zero_args_result(self):
+        # This follows the default behaviour in Python when executing `all([])`
         return True
 
 
@@ -118,7 +119,8 @@ class Or(BoolOp):
         return lhs or rhs
 
     def _zero_args_result(self):
-        return True
+        # This follows the default behaviour in Python when executing `any([])`
+        return False
 
 
 class ArithOp(BinaryOp):

--- a/tests/conditions_test.yaml
+++ b/tests/conditions_test.yaml
@@ -31,6 +31,16 @@ test_suites:
           - condition:
               and: []
             expected_result: true
+  # Just check we can parse "all", since it's the same as "and"
+  - name: ALL
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition:
+              all:
+                - const: true
+                - const: true
+            expected_result: true
   - name: OR
     tests:
       - schemas: [v1alpha1]
@@ -49,6 +59,19 @@ test_suites:
               or:
                 - const: true
             expected_result: true
+          - condition:
+              or: []
+            expected_result: false
+  # Just check we can parse "any", since it's the same as "or"
+  - name: ANY
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition:
+              any:
+                - const: false
+                - const: false
+            expected_result: false
   - name: NOT
     tests:
       - schemas: [v1alpha1]
@@ -143,6 +166,20 @@ test_suites:
                   - maxCPU: 1
                   - maxCPU: 2
             expected_result: [2, 3]
+  # Just check we can parse "map", since it's the same as "forEach"
+  - name: MAP
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition:
+              map:
+                elements:
+                  const: [1, 2]
+                op:
+                  sum:
+                    - const: 10
+                    - getValue: "."
+            expected_result: [11, 12]
   - name: CONTAIN
     tests:
       - schemas: [v1alpha1]


### PR DESCRIPTION
This commit improves the name of certain operations. This change has an effect on v1beta1. However, to be able to consume configs written with v1alpha1, we're keeping the old names. The operations that now have a new alias are:

- "and" -> "all"
- "or" -> "any"
- "forEach" -> "map"

Apart from that, we're changing the behavior of "or" (and "any) when they have no operands. Before, the result was true, but now it's false. This makes this operation consistent with `any([])` in Python. The intention is to make its output more intuitive for Python users.