### PR TITLE
Add ability to do implicit nested loops on a "getValue"

### DIFF
--- a/generic_k8s_webhook/operators.py
+++ b/generic_k8s_webhook/operators.py
@@ -319,6 +319,9 @@ class GetValue(Operator):
         if len(path) == 0 or path[0] == "":
             return data
 
+        if path[0] == "*":
+            return self._evaluate_wildcard(data, path)
+
         if isinstance(data, dict):
             key = path[0]
             if key in data:
@@ -331,6 +334,18 @@ class GetValue(Operator):
             raise RuntimeError(f"Expected list or dict, but got {data}")
 
         return None
+
+    def _evaluate_wildcard(self, data: Union[list, dict], path: list):
+        if not isinstance(data, list):
+            raise RuntimeError(f"Expected list when evaluating '*', but got {data}")
+        l = []
+        for elem in data:
+            sublist = self._get_value_from_json(elem, path[1:])
+            if isinstance(sublist, list):
+                l.extend(sublist)
+            else:
+                l.append(sublist)
+        return l
 
     def input_type(self) -> type | None:
         return None

--- a/tests/conditions_test.yaml
+++ b/tests/conditions_test.yaml
@@ -138,6 +138,36 @@ test_suites:
                   spec: {}
               - name: bar
             expected_result: foo
+          # Evaluate a wildcard (1)
+          - condition:
+              getValue: .nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.*.preference.matchExpressions
+            context:
+              - nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                          - key: key1
+                    - preference:
+                        matchExpressions:
+                          - key: key2
+            expected_result:
+              - key: key1
+              - key: key2
+          # Evaluate a wildcard (2)
+          - condition:
+              getValue: .nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.*.preference.matchExpressions.*.key
+            context:
+              - nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                          - key: key1
+                    - preference:
+                        matchExpressions:
+                          - key: key2
+            expected_result:
+              - key1
+              - key2
   - name: FOR_EACH
     tests:
       - schemas: [v1alpha1]


### PR DESCRIPTION
The implicit nested loops are defined using a "*". For example, we can now iterate over all the container names by doing
".spec.containers.*.name"