### PR TITLE
Ability to parse expressions that can filter and/or map a list

### DIFF
--- a/generic_k8s_webhook/config_parser/entrypoint.py
+++ b/generic_k8s_webhook/config_parser/entrypoint.py
@@ -110,6 +110,7 @@ class GenericWebhookConfigManifest:
                         op_parser.ForEachParser,
                         op_parser.MapParser,
                         op_parser.ContainParser,
+                        op_parser.FilterParser,
                         op_parser.ConstParser,
                         op_parser.GetValueParser,
                     ],

--- a/generic_k8s_webhook/config_parser/operator_parser.py
+++ b/generic_k8s_webhook/config_parser/operator_parser.py
@@ -239,6 +239,24 @@ class MapParser(ForEachParser):
         return "map"
 
 
+class FilterParser(OperatorParser):
+    @classmethod
+    def get_name(cls) -> str:
+        return "filter"
+
+    def parse(self, op_inputs: dict | list, path_op: str) -> operators.Filter:
+        raw_elements = utils.must_get(op_inputs, "elements", f"In {path_op}, required 'elements'")
+        elements = self.meta_op_parser.parse(raw_elements, f"{path_op}.elements")
+
+        raw_op = utils.must_get(op_inputs, "op", f"In {path_op}, required 'op'")
+        op = self.meta_op_parser.parse(raw_op, f"{path_op}.op")
+
+        try:
+            return operators.Filter(elements, op)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}") from e
+
+
 class ContainParser(OperatorParser):
     @classmethod
     def get_name(cls) -> str:

--- a/generic_k8s_webhook/operators.py
+++ b/generic_k8s_webhook/operators.py
@@ -273,6 +273,30 @@ class ForEach(Operator):
         return list[self.op.return_type()]
 
 
+class Filter(Operator):
+    def __init__(self, elements: Operator, op: Operator) -> None:
+        self.elements = elements
+        self.op = op
+
+    def get_value(self, contexts: list):
+        elements = self.elements.get_value(contexts)
+        if elements is None:
+            return []
+
+        result_list = []
+        for elem in elements:
+            mapped_elem = self.op.get_value(contexts + [elem])
+            if mapped_elem:
+                result_list.append(elem)
+        return result_list
+
+    def input_type(self) -> type | None:
+        return None
+
+    def return_type(self) -> type | None:
+        return list[self.op.return_type()]
+
+
 class Contain(Operator):
     def __init__(self, elements: Operator, elem: Operator) -> None:
         self.elements = elements

--- a/tests/conditions_test.yaml
+++ b/tests/conditions_test.yaml
@@ -236,6 +236,22 @@ test_suites:
                   - maxCPU: 1
                   - maxCPU: 2
             expected_result: false
+  - name: FILTER
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition:
+              filter:
+                elements:
+                  getValue: .containers
+                op: .maxCPU < 2
+            context:
+              - containers:
+                  - name: container1
+                    maxCPU: 1
+                  - name: container2
+                    maxCPU: 2
+            expected_result: [{ name: container1, maxCPU: 1 }]
   - name: RAW_STR_EXPR
     tests:
       - schemas: [v1beta1]
@@ -258,3 +274,27 @@ test_suites:
                   - maxCPU: 1
                   - maxCPU: 2
             expected_result: true
+  - name: LIST_FILTER_MAP_EXPR
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition: .containers | .name != "main"
+            context:
+              - containers:
+                  - name: main
+                  - name: istio
+            expected_result: [name: istio]
+          - condition: ".containers -> .maxCPU * 2"
+            context:
+              - containers:
+                  - maxCPU: 1
+                  - maxCPU: 2
+            expected_result: [2, 4]
+          - condition: .containers | .name != "main" -> .maxCPU > 1
+            context:
+              - containers:
+                  - name: main
+                    maxCPU: 1
+                  - name: istio
+                    maxCPU: 2
+            expected_result: [true]


### PR DESCRIPTION
These expressions have the following format:

```
<reference> (("|" "->") <expr>)
```

<reference> is a reference to a list in the yaml that we're processing. What we have on the right hand side is a filter ("|") or a map ("->"). The <expr> is the function used to filter or map the list in the left hand side. We can have multiple filters and/or maps on the right. For example, we can see if all the side containers request less than 1 cpu using the following expression:

```
all: .spec.containers | .name != "main" -> .requests.cpu < 1
```