### PR TITLE
Ability to use expressions in a json patch

### DIFF
--- a/generic_k8s_webhook/config_parser/action_parser.py
+++ b/generic_k8s_webhook/config_parser/action_parser.py
@@ -45,7 +45,7 @@ class ActionParserV1(IActionParser):
         condition = self.meta_op_parser.parse(raw_condition, f"{path_action}.condition")
 
         raw_patch = raw_config.pop("patch", [])
-        patch = self.json_patch_parser.parse(raw_patch)
+        patch = self.json_patch_parser.parse(raw_patch, f"{path_action}.patch")
 
         # By default, we always accept the payload
         accept = raw_config.pop("accept", True)

--- a/generic_k8s_webhook/config_parser/entrypoint.py
+++ b/generic_k8s_webhook/config_parser/entrypoint.py
@@ -4,7 +4,7 @@ import generic_k8s_webhook.config_parser.operator_parser as op_parser
 from generic_k8s_webhook import utils
 from generic_k8s_webhook.config_parser import expr_parser
 from generic_k8s_webhook.config_parser.action_parser import ActionParserV1
-from generic_k8s_webhook.config_parser.jsonpatch_parser import JsonPatchParserV1
+from generic_k8s_webhook.config_parser.jsonpatch_parser import JsonPatchParserV1, JsonPatchParserV2
 from generic_k8s_webhook.config_parser.webhook_parser import WebhookParserV1
 from generic_k8s_webhook.webhook import Webhook
 
@@ -95,29 +95,30 @@ class GenericWebhookConfigManifest:
         return list_webhook_config
 
     def _parse_v1beta1(self, raw_list_webhook_config: dict) -> list[Webhook]:
+        meta_op_parser = op_parser.MetaOperatorParser(
+            list_op_parser_classes=[
+                op_parser.AndParser,
+                op_parser.AllParser,
+                op_parser.OrParser,
+                op_parser.AnyParser,
+                op_parser.EqualParser,
+                op_parser.SumParser,
+                op_parser.StrConcatParser,
+                op_parser.NotParser,
+                op_parser.ListParser,
+                op_parser.ForEachParser,
+                op_parser.MapParser,
+                op_parser.ContainParser,
+                op_parser.FilterParser,
+                op_parser.ConstParser,
+                op_parser.GetValueParser,
+            ],
+            raw_str_parser=expr_parser.RawStringParserV1(),
+        )
         webhook_parser = WebhookParserV1(
             action_parser=ActionParserV1(
-                meta_op_parser=op_parser.MetaOperatorParser(
-                    list_op_parser_classes=[
-                        op_parser.AndParser,
-                        op_parser.AllParser,
-                        op_parser.OrParser,
-                        op_parser.AnyParser,
-                        op_parser.EqualParser,
-                        op_parser.SumParser,
-                        op_parser.StrConcatParser,
-                        op_parser.NotParser,
-                        op_parser.ListParser,
-                        op_parser.ForEachParser,
-                        op_parser.MapParser,
-                        op_parser.ContainParser,
-                        op_parser.FilterParser,
-                        op_parser.ConstParser,
-                        op_parser.GetValueParser,
-                    ],
-                    raw_str_parser=expr_parser.RawStringParserV1(),
-                ),
-                json_patch_parser=JsonPatchParserV1(),
+                meta_op_parser=meta_op_parser,
+                json_patch_parser=JsonPatchParserV2(meta_op_parser),
             )
         )
         list_webhook_config = [

--- a/tests/jsonpatch_test.yaml
+++ b/tests/jsonpatch_test.yaml
@@ -126,3 +126,14 @@ test_suites:
               value: foo
             payload: { spec: {}, metadata: { name: foo } }
             expected_result: { spec: {}, metadata: { name: foo } }
+  - name: EXPR
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          # Add a prefix
+          - patch:
+              op: expr
+              path: .metadata.name
+              value: '"prefix-" ++ .metadata.name'
+            payload: { spec: {}, metadata: { name: foo } }
+            expected_result: { spec: {}, metadata: { name: prefix-foo } }


### PR DESCRIPTION
Introducing the JsonPatchParserV2. This new json patch parser is backwards compatible with the already supported json patch operations. On top of that, it adds the ability to use expressions to generate new values on a json patch operation. For example, we can add a prefix to the pod name:

```
op: expr
path: .metadata.name
value: '"prefix-" ++ .metadata.name'
```