### PR TITLE
Ability to use a forEach on a jsonpatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format: build
 
 .PHONY: unittests
 unittests: build
-	poetry run pytest tests
+	poetry run pytest tests --cov=generic_k8s_webhook
 	poetry run coverage html
 
 .PHONY: check-pyproject

--- a/generic_k8s_webhook/config_parser/expr_parser.py
+++ b/generic_k8s_webhook/config_parser/expr_parser.py
@@ -167,7 +167,6 @@ class IRawStringParser(abc.ABC):
 
     def parse(self, raw_string: str) -> op.Operator:
         tree = self.parser.parse(raw_string)
-        print(tree.pretty())  # debug mode
         operator = self.transformer.transform(tree)
         return operator
 

--- a/generic_k8s_webhook/config_parser/jsonpatch_parser.py
+++ b/generic_k8s_webhook/config_parser/jsonpatch_parser.py
@@ -1,7 +1,7 @@
 import abc
 
 import generic_k8s_webhook.config_parser.operator_parser as op_parser
-from generic_k8s_webhook import jsonpatch_helpers, utils
+from generic_k8s_webhook import jsonpatch_helpers, operators, utils
 from generic_k8s_webhook.config_parser.common import ParsingException
 
 
@@ -16,6 +16,36 @@ class ParserOp(abc.ABC):
         if path[0] != "":
             raise ValueError(f"The first element of a path in the patch must be '.', not {path[0]}")
         return path[1:]
+
+
+class IJsonPatchParser(abc.ABC):
+    def parse(self, raw_patch: list, path_op: str) -> list[jsonpatch_helpers.JsonPatchOperator]:
+        patch = []
+        dict_parse_op = self._get_dict_parse_op()
+        for i, raw_elem in enumerate(raw_patch):
+            op = utils.must_pop(raw_elem, "op", f"Missing key 'op' in {raw_elem}")
+
+            # Select the appropiate class needed to parse the operation "op"
+            if op not in dict_parse_op:
+                raise ParsingException(f"Unsupported patch operation {op} on {path_op}")
+            parse_op = dict_parse_op[op]
+            try:
+                parsed_elem = parse_op.parse(raw_elem, f"{path_op}.{i}")
+            except Exception as e:
+                raise ParsingException(f"Error when parsing {path_op}") from e
+
+            # Make sure we have extracted all the keys from "raw_elem"
+            if len(raw_elem) > 0:
+                raise ValueError(f"Unexpected keys {raw_elem}")
+            patch.append(parsed_elem)
+
+        return patch
+
+    @abc.abstractmethod
+    def _get_dict_parse_op(self) -> dict[str, ParserOp]:
+        """A dictionary with the classes that can parse the json patch operations
+        supported by this JsonPatchParser
+        """
 
 
 class ParseAdd(ParserOp):
@@ -70,34 +100,23 @@ class ParseExpr(ParserOp):
         return jsonpatch_helpers.JsonPatchExpr(path, operator)
 
 
-class IJsonPatchParser(abc.ABC):
-    def parse(self, raw_patch: list, path_op: str) -> list[jsonpatch_helpers.JsonPatchOperator]:
-        patch = []
-        dict_parse_op = self._get_dict_parse_op()
-        for i, raw_elem in enumerate(raw_patch):
-            op = utils.must_pop(raw_elem, "op", f"Missing key 'op' in {raw_elem}")
+class ParseForEach(ParserOp):
+    def __init__(self, meta_op_parser: op_parser.MetaOperatorParser, jsonpatch_parser: IJsonPatchParser) -> None:
+        self.meta_op_parser = meta_op_parser
+        self.jsonpatch_parser = jsonpatch_parser
 
-            # Select the appropiate class needed to parse the operation "op"
-            if op not in dict_parse_op:
-                raise ParsingException(f"Unsupported patch operation {op} on {path_op}")
-            parse_op = dict_parse_op[op]
-            try:
-                parsed_elem = parse_op.parse(raw_elem, f"{path_op}.{i}")
-            except Exception as e:
-                raise ParsingException(f"Error when parsing {path_op}") from e
-
-            # Make sure we have extracted all the keys from "raw_elem"
-            if len(raw_elem) > 0:
-                raise ValueError(f"Unexpected keys {raw_elem}")
-            patch.append(parsed_elem)
-
-        return patch
-
-    @abc.abstractmethod
-    def _get_dict_parse_op(self) -> dict[str, ParserOp]:
-        """A dictionary with the classes that can parse the json patch operations
-        supported by this JsonPatchParser
-        """
+    def parse(self, raw_elem: dict, path_op: str) -> jsonpatch_helpers.JsonPatchOperator:
+        elems = utils.must_pop(raw_elem, "elements", f"Missing key 'elements' in {raw_elem}")
+        op = self.meta_op_parser.parse(elems, f"{path_op}.elements")
+        if not isinstance(op, operators.OperatorWithRef):
+            raise ParsingException(
+                f"The expression in {path_op}.elements must reference elements in the json that we want to patch"
+            )
+        list_raw_patch = utils.must_pop(raw_elem, "patch", f"Missing key 'patch' in {raw_elem}")
+        if not isinstance(list_raw_patch, list):
+            raise ParsingException(f"In {path_op}.patch we expect a list of patch, but got {list_raw_patch}")
+        jsonpatch_op = self.jsonpatch_parser.parse(list_raw_patch, f"{path_op}.patch")
+        return jsonpatch_helpers.JsonPatchForEach(op, jsonpatch_op)
 
 
 class JsonPatchParserV1(IJsonPatchParser):
@@ -131,7 +150,5 @@ class JsonPatchParserV2(JsonPatchParserV1):
 
     def _get_dict_parse_op(self) -> dict[str, ParserOp]:
         dict_parse_op_v1 = super()._get_dict_parse_op()
-        dict_parse_op_v2 = {
-            "expr": ParseExpr(self.meta_op_parser),
-        }
+        dict_parse_op_v2 = {"expr": ParseExpr(self.meta_op_parser), "forEach": ParseForEach(self.meta_op_parser, self)}
         return {**dict_parse_op_v1, **dict_parse_op_v2}

--- a/generic_k8s_webhook/webhook.py
+++ b/generic_k8s_webhook/webhook.py
@@ -13,17 +13,17 @@ class Action:
     def check_condition(self, manifest: dict) -> bool:
         return self.condition.get_value([manifest])
 
-    def get_patches(self, manifest: dict) -> jsonpatch.JsonPatch | None:
+    def get_patches(self, json_payload: dict) -> jsonpatch.JsonPatch | None:
         if not self.list_jpatch_op:
             return None
 
-        # 1. Generate a json patch specific for the manifest
-        # 2. Update the manifest based on that patch
+        # 1. Generate a json patch specific for the json_payload
+        # 2. Update the json_payload based on that patch
         # 3. Extract the raw patch, so we can merge later all the patches into a single JsonPatch object
         list_raw_patches = []
         for jpatch_op in self.list_jpatch_op:
-            jpatch = jpatch_op.generate_patch(manifest)
-            manifest = jpatch.apply(manifest)
+            jpatch = jpatch_op.generate_patch([json_payload])
+            json_payload = jpatch.apply(json_payload)
             list_raw_patches.extend(jpatch.patch)
 
         return jsonpatch.JsonPatch(list_raw_patches)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ fixme, \
 """
 
 [tool.pytest.ini_options]
-addopts = "-v --timeout=15 --cov=generic_k8s_webhook"
+addopts = "-v --timeout=15"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/jsonpatch_test.yaml
+++ b/tests/jsonpatch_test.yaml
@@ -137,3 +137,59 @@ test_suites:
               value: '"prefix-" ++ .metadata.name'
             payload: { spec: {}, metadata: { name: foo } }
             expected_result: { spec: {}, metadata: { name: prefix-foo } }
+  - name: FOR_EACH
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          # Add a prefix to all the container names
+          - patch:
+              op: forEach
+              elements: .spec.containers
+              patch:
+                - op: expr
+                  path: .name
+                  value: '"prefix-" ++ .name'
+            payload: { spec: { containers: [{ name: foo }, { name: bar }] } }
+            expected_result:
+              spec: { containers: [{ name: prefix-foo }, { name: prefix-bar }] }
+          # Add a prefix (the namespace) to all the container names
+          - patch:
+              op: forEach
+              elements: .spec.containers
+              patch:
+                - op: expr
+                  path: .name
+                  value: $.metadata.namespace ++ "-" ++ .name
+            payload:
+              spec: { containers: [{ name: foo }, { name: bar }] }
+              metadata: { namespace: default }
+            expected_result:
+              spec:
+                containers: [{ name: default-foo }, { name: default-bar }]
+              metadata: { namespace: default }
+          # Multiple patches concatened within a forEach
+          - patch:
+              op: forEach
+              elements: .spec.containers
+              patch:
+                - op: expr
+                  path: .requests.cpu
+                  value: .requests.cpu / 2
+                - op: remove
+                  path: .limits
+            payload:
+              spec:
+                containers:
+                  - name: foo
+                    requests: { cpu: 2 }
+                    limits: { cpu: 3, memory: 4 }
+                  - name: bar
+                    requests: { cpu: 4 }
+                    limits: { cpu: 3, memory: 4 }
+            expected_result:
+              spec:
+                containers:
+                  - name: foo
+                    requests: { cpu: 1 }
+                  - name: bar
+                    requests: { cpu: 2 }


### PR DESCRIPTION
Now, we can iterate over a list and apply a jsonpatch on each element of the list. For example, we can remove the limits on all the containers from a pod:

```yaml
patch:
  op: forEach
  elements: .spec.containers
  patch:
    - op: remove
      path: .limits
```