### PR TITLE
Ability to process a str expression directly as a list

### DIFF
--- a/generic_k8s_webhook/main.py
+++ b/generic_k8s_webhook/main.py
@@ -24,12 +24,14 @@ def cli(args):
             accept, patch = webhook.process_manifest(k8s_manifest)
             if not accept:
                 sys.exit(1)
-            # Show the patch if it's not None
             if patch:
+                # Show the patch if it's not None
                 if args.show_patch:
                     print(json.dumps(patch.patch, indent=2))
                 else:
                     print(yaml.dump(patch.apply(k8s_manifest), indent=2))
+            else:
+                logging.info("No changes")
             sys.exit(0)
     logging.error(
         f"Couldn't find a webhook called {args.wh_name}. "
@@ -95,11 +97,12 @@ def parse_args() -> argparse.ArgumentParser:
 
 def main():
     args = parse_args()
-    logging.basicConfig(format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s")
     if args.verbose > 0:
         logging.basicConfig(
             format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s", level=logging.INFO
         )
+    else:
+        logging.basicConfig(format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s")
     args.func(args)
 
 

--- a/tests/conditions_test.yaml
+++ b/tests/conditions_test.yaml
@@ -314,3 +314,31 @@ test_suites:
                   - name: istio
                     maxCPU: 2
             expected_result: [true]
+  - name: BINARY_OP_ON_STR_LIST_MAP
+    tests:
+      - schemas: [v1beta1]
+        cases:
+          - condition:
+              all: .nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.*.preference.matchExpressions.* -> .key != "myKey"
+            context:
+              - nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                          - key: key1
+                    - preference:
+                        matchExpressions:
+                          - key: key2
+            expected_result: true
+          - condition:
+              all: .nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.*.preference.matchExpressions.* -> .key != "myKey"
+            context:
+              - nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                          - key: key1
+                    - preference:
+                        matchExpressions:
+                          - key: myKey
+            expected_result: false


### PR DESCRIPTION
With this change, the following expression:

```
all:
  getValue: .path.to.list -> .elem == "something"
```

can be simplified to:

```
all: .path.to.list -> .elem == "something"
```

This commit also make clearer when the webhook won't apply any change to the K8S manifest that is processing. This applies when using the webhook in cli mode.