### PR TITLE
Fix problem when adding an element on the index 0 of a list

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -23,10 +23,11 @@ jobs:
           make pkg
           mv ./dist/main ./generic-k8s-webhook-linux-${{github.ref_name}}
 
-      - name: Publish package
-        uses: softprops/action-gh-release@v2
-        with:
-          files: generic-k8s-webhook-linux-${{github.ref_name}}
+      # FIXME Uncomment this once we enable softprops/action-gh-release@v2
+      # - name: Publish package
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     files: generic-k8s-webhook-linux-${{github.ref_name}}
 
   build-and-publish-to-ghcr:
     # Explicitly grant the `secrets.GITHUB_TOKEN` permissions.

--- a/generic_k8s_webhook/jsonpatch_helpers.py
+++ b/generic_k8s_webhook/jsonpatch_helpers.py
@@ -77,7 +77,7 @@ class JsonPatchAdd(JsonPatchOperator):
             # The rest of non-existing keys must be part of the "values"
             items_to_create = self.path[len(new_path) :]
             for key in reversed(items_to_create):
-                if key == "-":
+                if key in ["-", "0"]:
                     new_value = [new_value]
                 else:
                     new_value = {key: new_value}

--- a/tests/jsonpatch_test.yaml
+++ b/tests/jsonpatch_test.yaml
@@ -59,6 +59,14 @@ test_suites:
             payload: { spec: {}, metadata: {} }
             expected_result:
               { spec: { containers: [{ name: main }] }, metadata: {} }
+          # Add an element to a non-existing list
+          - patch:
+              op: add
+              path: .spec.containers.0
+              value: { name: main }
+            payload: { spec: {}, metadata: {} }
+            expected_result:
+              { spec: { containers: [{ name: main }] }, metadata: {} }
           # Add a new entry on the second element of the list
           - patch:
               op: add


### PR DESCRIPTION
This problem happened when the list doesn't exist on the original yaml. In this situation, the new element was added as a dictionary of key "0". Now, with the current fix, the list is properly created and the element is added as a normal list element.

Apart from that, we've commented the step that pushes the self-contained package to the release since we need to enable first "softprops/action-gh-release@v2".