### PR TITLE
Ability to set multiple webhooks on the same path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ actions:
 
 ```
 
+If more than one webhook have the same path, they will be called in order. The `accept` responses are ANDed and the `patch` responses are concatenated. Notice that a given webhook will receive the payload already modified by all the previous webhooks that have the same path.
+
 The syntax of the `condition` can be found in [Defining a condition](#defining-a-condition). The syntax of the patch can be found in [Defining a patch](#defining-a-patch).
 
 ### Testing the `GenericWebhookConfig` file is correct

--- a/generic_k8s_webhook/webhook.py
+++ b/generic_k8s_webhook/webhook.py
@@ -14,9 +14,6 @@ class Action:
         return self.condition.get_value([manifest])
 
     def get_patches(self, json_payload: dict) -> jsonpatch.JsonPatch | None:
-        if not self.list_jpatch_op:
-            return None
-
         # 1. Generate a json patch specific for the json_payload
         # 2. Update the json_payload based on that patch
         # 3. Extract the raw patch, so we can merge later all the patches into a single JsonPatch object
@@ -42,4 +39,4 @@ class Webhook:
                 return action.accept, patches
 
         # If no condition is met, we'll accept the manifest without any patch
-        return True, None
+        return True, jsonpatch.JsonPatch([])

--- a/tests/http_server_test.py
+++ b/tests/http_server_test.py
@@ -18,7 +18,8 @@ HTTP_SERVER_TEST_DATA_DIR = os.path.join(SCRIPT_DIR, "http_server_test_data")
 @pytest.mark.parametrize(
     ("name_test", "req", "webhook_config", "expected_response"),
     load_test_case(os.path.join(HTTP_SERVER_TEST_DATA_DIR, "test_case_1.yaml"))
-    + load_test_case(os.path.join(HTTP_SERVER_TEST_DATA_DIR, "test_case_3.yaml")),
+    + load_test_case(os.path.join(HTTP_SERVER_TEST_DATA_DIR, "test_case_3.yaml"))
+    + load_test_case(os.path.join(HTTP_SERVER_TEST_DATA_DIR, "test_case_4.yaml")),
 )
 def test_http_server(name_test, req, webhook_config, expected_response, tmp_path):
     webhook_config_file = tmp_path / "webhook_config.yaml"

--- a/tests/http_server_test_data/test_case_4.yaml
+++ b/tests/http_server_test_data/test_case_4.yaml
@@ -1,0 +1,75 @@
+request:
+  path: /my-webhook
+  body:
+    apiVersion: admission.k8s.io/v1
+    kind: AdmissionReview
+    request:
+      uid: "1234"
+      object:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: experimental-descheduler
+          namespace: kube-system
+          labels:
+            app.kubernetes.io/name: descheduler
+            app.kubernetes.io/version: "0.27.1"
+
+webhook_config:
+  apiVersion: generic-webhook/v1beta1
+  kind: GenericWebhookConfig
+  webhooks:
+    - name: my-webhook-1
+      path: /my-webhook
+      actions:
+        # Refuse the request if the name is "random-name"
+        - condition: .metadata.name == "random-name"
+          accept: false
+        # Otherwise, accept it and add a label
+        - accept: true
+          patch:
+            - op: add
+              path: .metadata.labels
+              value:
+                myLabel: myValue
+
+    - name: my-webhook-2
+      path: /my-webhook
+      actions:
+        # Add another label if myLabel is present. This only happens if the previous
+        # call to my-webhook-1 went through the second action
+        - condition: .metadata.labels.myLabel == "myValue"
+          patch:
+            - op: add
+              path: .metadata.labels
+              value:
+                otherLabel: otherValue
+
+cases:
+  - patches: []
+    expected_response:
+      apiVersion: admission.k8s.io/v1
+      kind: AdmissionReview
+      response:
+        uid: "1234"
+        allowed: True
+        patchType: JSONPatch
+        patch:
+          - op: add
+            path: /metadata/labels
+            value:
+              myLabel: myValue
+          - op: add
+            path: /metadata/labels
+            value:
+              otherLabel: otherValue
+
+  - patches:
+      - key: [request, body, request, object, metadata, name]
+        value: random-name
+    expected_response:
+      apiVersion: admission.k8s.io/v1
+      kind: AdmissionReview
+      response:
+        uid: "1234"
+        allowed: False


### PR DESCRIPTION
If we define different webhooks with the same value on the "path" field, then these webhooks will be called in sequence when the server receives a request for the given path. The resulting "accept" responses will be ANDed and the patches will be concatenated. Notice that a given webhook will see the patches from the previous webhooks already applied to the object that it must inspect.